### PR TITLE
fix: Remove `escaped_by` parameter which will be no longer supported

### DIFF
--- a/src/main/java/keboola/adform/masterdata_extractor/Runner.java
+++ b/src/main/java/keboola/adform/masterdata_extractor/Runner.java
@@ -134,8 +134,7 @@ public class Runner {
                 String manifest = "destination: " + resFileName + "\n"
                         + "incremental: true\n"
                         + "delimiter: \"\\t\"\n"
-                        + "enclosure: \"\"\n"
-                        + "escaped_by: \"\"";
+                        + "enclosure: \"\"";
                 File manifestFile = new File(outTablesPath + File.separator + resFileName + ".csv.manifest");
                 try {
                     Files.write(manifest, manifestFile, Charset.forName("UTF-8"));
@@ -192,8 +191,7 @@ public class Runner {
                     String manifest = "destination: " + resFileName + "\n"
                             + "incremental: false\n"
                             + "delimiter: \"\\t\"\n"
-                            + "enclosure: \"\"\n"
-                            + "escaped_by: \"\"";
+                            + "enclosure: \"\"";
                     File manifestFile = new File(outTablesPath + File.separator + resFileName + ".csv.manifest");
                     try {
                         Files.write(manifest, manifestFile, Charset.forName("UTF-8"));


### PR DESCRIPTION
Hi,
We found out that because of internal database requirements, the `escaped_by` parameter cannot have any other value than empty and we would like to remove it entirely.
